### PR TITLE
fix: handle case when value is not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@
 [![npm](https://img.shields.io/npm/dt/eslint-plugin-playlyfe.svg?style=flat-square)](https://www.npmjs.com/package/eslint-plugin-playlyfe)
 [![David](https://img.shields.io/david/mayank1791989/eslint-plugin-playlyfe.svg?style=flat-square)](https://david-dm.org/Mayank1791989/eslint-plugin-playlyfe)
 [![David](https://img.shields.io/david/dev/Mayank1791989/eslint-plugin-playlyfe.svg?style=flat-square)](https://david-dm.org/Mayank1791989/eslint-plugin-playlyfe#info=devDependencies)
+
+## Rules
+
+The following rules are provided:
+
+### react-intl
+
+1. `react-intl-no-empty-translation`: find empty translations in the generated i18n file
+2. `react-intl-no-missing-id`: find keys in code which are not in translated file [autofix available]
+3. `react-intl-no-undef-id`: find keys in i18n files which are not in code.
+4. `react-intl-no-untranslated-string`: find strings in source code which should translated, but are not.
+
+### React
+1. `react-style-no-numeric-string-value`: Rule to enforce https://github.com/facebook/react/issues/1357.
+
+### Relay
+1. `relay-no-missing-variable-in-props`: find relay variables which are not in props.
+
+### Misc
+1. `use-exact-dependency`: check dependencies in package.json are exact.

--- a/src/rules/__tests__/react-intl-no-untranslated-string.js
+++ b/src/rules/__tests__/react-intl-no-untranslated-string.js
@@ -53,6 +53,14 @@ ruleTester.run('react-intl-no-untranslated-string', rule, {
       parser: 'babel-eslint',
     },
 
+    { // don't crash for non-string attributes
+      code: '<div title={false} />',
+      errors: [
+        error({line: 1, column: 13}),
+      ],
+      parser: 'babel-eslint',
+    },
+
     {
       code: '<div title={`string ${h} hello`} />',
       errors: [

--- a/src/rules/react-intl-no-untranslated-string.js
+++ b/src/rules/react-intl-no-untranslated-string.js
@@ -18,7 +18,7 @@ module.exports = (context) => {
 
   function findCorrectLocation(node) { // remove whitespace from loc start
     let { line, column } = node.loc.start;
-    if (node.type === 'Literal') { // find loc of first non whitespace character
+    if (node.type === 'Literal' && (typeof node.value === 'string' || node.value instanceof String)) { // find loc of first non whitespace character
       const value = node.value.split('\n');
       value.findIndex((rowString, index) => { // here using findIndex to bail on first find
         const pos = rowString.search(/\S/);

--- a/src/rules/react-intl-no-untranslated-string.js
+++ b/src/rules/react-intl-no-untranslated-string.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview find empty translation in file
+ * @fileoverview find strings in source code which should translated, but are not
  * @author Mayank Agarwal
  */
 //------------------------------------------------------------------------------

--- a/src/rules/relay-no-missing-variable-in-props.js
+++ b/src/rules/relay-no-missing-variable-in-props.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview find keys in i18n files which are not in code
+ * @fileoverview find relay variables which are not in props
  * @author Mayank Agarwal
  */
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There is a case, namely:
```
<input placeholder={false} />
```
which causes eslint to crash with a 'node.value.split is not a function' error. This patch fixes that.